### PR TITLE
Make Buffer:add_utf8 support item_offset and item_length.

### DIFF
--- a/luaharfbuzz-0.0.2-0.rockspec
+++ b/luaharfbuzz-0.0.2-0.rockspec
@@ -1,7 +1,8 @@
 package = "luaharfbuzz"
-version = "0.0.1-1"
+version = "0.0.2-0"
 source = {
   url = "git://github.com/deepakjois/luaharfbuzz",
+  tag = "v0.0.2"
 }
 description = {
   summary = "Lua bindings for the Harfbuzz text shaping library",

--- a/spec/buffer_spec.lua
+++ b/spec/buffer_spec.lua
@@ -7,7 +7,26 @@ describe("harfbuzz.Buffer", function()
 
   it("can add a UTF8 string to the buffer", function()
     local b = harfbuzz.Buffer.new()
-    b:add_utf8("Some String")
+    local s = "Some String"
+    b:add_utf8(s)
+    assert.are_equal(string.len(s), b:get_length())
+  end)
+
+  it("can add a UTF 8 string with item_offset", function()
+    local b = harfbuzz.Buffer.new()
+    local s = "Some String"
+    local o = 5
+    b:add_utf8(s,o)
+    assert.are_equal(string.len(s) - o, b:get_length())
+  end)
+
+  it("can add a UTF 8 string with item_offset", function()
+    local b = harfbuzz.Buffer.new()
+    local s = "Some String"
+    local o = 5
+    local l = 2
+    b:add_utf8(s,o,l)
+    assert.are_equal(l, b:get_length())
   end)
 
   it("can call guess_segment_properties", function()
@@ -99,6 +118,13 @@ describe("harfbuzz.Buffer", function()
       assert.are_equal(g.y_offset, r.y_offset)
     end
 
+  end)
+
+  it("can get the length of the buffer", function()
+    local b = harfbuzz.Buffer.new()
+    local s = "some string"
+    b:add_utf8(s)
+    assert.are_equal(string.len(s), b:get_length())
   end)
 end)
 

--- a/src/harfbuzz.lua
+++ b/src/harfbuzz.lua
@@ -11,6 +11,14 @@ function hb.Face.new(file, font_index)
   return hb.Face.new_from_blob(blob,i)
 end
 
+local buffer_metatable = getmetatable(hb.Buffer)
+
+function buffer_metatable.add_utf8(self, text, item_offset, item_length)
+  item_offset = item_offset or 0
+  item_length = item_length or -1
+  return self:add_utf8_c(text,item_offset,item_length)
+end
+
 hb.shape = function(font, buf, options)
   options = options or { }
 

--- a/src/harfbuzz.luadoc
+++ b/src/harfbuzz.luadoc
@@ -83,6 +83,8 @@
 
 --- Wraps `hb_buffer_add_utf8`.
 --  @param text UTF8 encoded string.
+--  @param item_offset _(optional)_ 0-indexed offset in `text`, from where to start adding (defaults to 0)
+--  @param item_length _(optional)_ length to add from `item_offset` (defaults to -1, which adds till end of&nbsp;`text`)
 --  @function Buffer:add_utf8
 
 --- Wraps `hb_buffer_set_direction`.
@@ -108,6 +110,9 @@
 
 --- Wraps `hb_buffer_reverse`.
 --  @function Buffer:reverse
+
+--- Wraps `hb_buffer_get_length`
+--  @function Buffer:get_length
 
 --- Wraps `hb_buffer_guess_segment_properties`.
 --  @function Buffer:guess_segment_properties

--- a/src/luaharfbuzz/buffer.c
+++ b/src/luaharfbuzz/buffer.c
@@ -96,8 +96,10 @@ static int buffer_add_utf8(lua_State *L) {
   Buffer *b = (Buffer *)luaL_checkudata(L, 1, "harfbuzz.Buffer");
 
   const char *text = luaL_checkstring(L, 2);
+  unsigned int item_offset = luaL_checkint(L,3);
+  int item_length = luaL_checkint(L,4);
 
-  hb_buffer_add_utf8(*b, text, strlen(text), 0, strlen(text));
+  hb_buffer_add_utf8(*b, text, -1, item_offset, item_length);
 
   return 0;
 }
@@ -146,9 +148,17 @@ static int buffer_reverse(lua_State *L) {
   return 0;
 }
 
+static int buffer_get_length(lua_State *L) {
+  Buffer *b = (Buffer *)luaL_checkudata(L, 1, "harfbuzz.Buffer");
+
+  lua_pushinteger(L, hb_buffer_get_length(*b));
+
+  return 1;
+}
+
 static const struct luaL_Reg buffer_methods[] = {
 	{ "__gc", buffer_destroy },
-  { "add_utf8", buffer_add_utf8 },
+  { "add_utf8_c", buffer_add_utf8 },
   { "set_direction", buffer_set_direction },
   { "get_direction", buffer_get_direction },
   { "set_language", buffer_set_language },
@@ -158,7 +168,8 @@ static const struct luaL_Reg buffer_methods[] = {
   { "get_glyph_infos_and_positions", buffer_get_glyph_infos_and_positions },
   { "guess_segment_properties", buffer_guess_segment_properties },
   { "reverse", buffer_reverse },
-  { NULL, NULL },
+  { "get_length", buffer_get_length },
+  { NULL, NULL }
 };
 
 static const struct luaL_Reg buffer_functions[] = {

--- a/status/done.txt
+++ b/status/done.txt
@@ -6,6 +6,7 @@ hb_buffer_create
 hb_buffer_destroy
 hb_buffer_get_direction
 hb_buffer_get_language
+hb_buffer_get_length
 hb_buffer_get_script
 hb_buffer_guess_segment_properties
 hb_buffer_reverse


### PR DESCRIPTION
* Added `Buffer:get_length` which wraps `hb_buffer_get_length`.
* Added docs.
* Version bump.
* Fix #20.