### PR TITLE
Add support for custom Lua header file inclusion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
 PKGS = harfbuzz
 
-CFLAGS = -O2 -fpic -std=c99 `pkg-config --cflags $(PKGS)` `pkg-config --cflags lua`
-LDFLAGS = -O2 -fpic `pkg-config --libs $(PKGS)`
+# override CFLAGS+= -fpic -O0 -g `pkg-config --cflags $(PKGS)` 
+override CFLAGS+= -O2 -fpic -std=c99 `pkg-config --cflags $(PKGS)` 
+ifdef LUA_INCDIR
+	LUA_INC = -I $(LUA_INCDIR)
+else
+	LUA_INC=`pkg-config --cflags lua`
+endif
+
+LDFLAGS = -g  -O3 -Wall `pkg-config --libs $(PKGS)` 
 
 # Guide to building Lua Modules: http://lua-users.org/wiki/BuildingModules
 UNAME_S := $(shell uname -s)
@@ -29,7 +36,7 @@ luaharfbuzz.so: $(OBJECTS)
 	$(CC) $(LDFLAGS) $(LIBFLAGS) $(OBJECTS) -o $@
 
 $(BUILD_DIR)/%.o: $(C_SRC_ROOT)/%.c
-	$(CC) $(CFLAGS) -o $@ -c $<
+	$(CC) $(CFLAGS) $(LUA_INC) -o $@ -c $<
 
 dirs: ${BUILD_DIR}
 

--- a/luaharfbuzz-0.0.5-0.rockspec
+++ b/luaharfbuzz-0.0.5-0.rockspec
@@ -15,6 +15,14 @@ dependencies = {
 }
 build = {
   type = "make",
+  build_variables = {
+    CFLAGS="$(CFLAGS)",
+    LIBFLAG="$(LIBFLAG)",
+    LUA_LIBDIR="$(LUA_LIBDIR)",
+    LUA_BINDIR="$(LUA_BINDIR)",
+    LUA_INCDIR="$(LUA_INCDIR)",
+    LUA="$(LUA)",
+  },
   install_variables = {
     INST_LIBDIR="$(LIBDIR)",
     INST_LUADIR="$(LUADIR)",


### PR DESCRIPTION
When I tried to include `luaharfbuzz` in testing file on Fedora 23, I've got the following runtime error with `texlua`:

     version mismatch: app. needs 503, Lua core provides 502

Lua version in Fedora is 5.3, while LuaTeX uses 5.2, so it seems that there is a version mismatch. Incidentally, I've tried the [Swiglib](http://www.luatex.org/swiglib.html) at the same time. Swiglib uses binary libraries with LuaTeX as well, but it works on my system correctly. I've figured out that the difference is that it uses Lua 5.2 header files for the C files compilation. 

I've tried to compile Luaharfbuzz with Lua 5.2 headers and it really works. Maybe there is some more clean way of supporting Lua 5.2 binary libraries on systems with Lua 5.3?

Anyway, I took a look at [some advises for Makefiles](https://github.com/luarocks/luarocks/wiki/Creating-a-Makefile-that-plays-nice-with-LuaRocks) when [used with Luarocks](https://github.com/luarocks/luarocks/wiki/Recommended-practices-for-Makefiles) and modified the Makefile and the rocks file to incorporate `LUA_INCDIR` variable, which can be passed to `make` or `luarocks` like 

      make LUA_INCDIR='path/to/lua_5.2/headers/'

Also other variables, like `CFLAGS`, can be set on the command line.